### PR TITLE
[UTILS] Add save/remove functionality of event handlers for each controller

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,5 +12,5 @@
 </body>
 <script src="/static/dist/handlebars.runtime.js"></script>
 <script src="/js/bundle.handlebars.js"></script>
-<script src="/js/index.js" type="module"></script>
+<script src="/static/dist/bundle.js" type="module"></script>
 </html>

--- a/public/js/controllers/big-event-search-controller.js
+++ b/public/js/controllers/big-event-search-controller.js
@@ -29,12 +29,14 @@ export default class BigEventSearchController extends Controller {
             .then((events) => {
                 console.log(events);
                 this.view.render(events);
-                document.getElementById('searchInput')
-                    .addEventListener('keydown', this.#completeRequest.bind(this));
+                this.addEventHandler(document.getElementById('searchInput'), 'keydown', this.#completeRequest);
+                // document.getElementById('searchInput')
+                //     .addEventListener('keydown', this.#completeRequest.bind(this));
             }).catch(onerror => {
                 this.view.render();
-                 document.getElementById('searchInput')
-                     .addEventListener('keydown', this.#completeRequest.bind(this));
+                this.addEventHandler(document.getElementById('searchInput'), 'keydown', this.#completeRequest);
+                // document.getElementById('searchInput')
+                //     .addEventListener('keydown', this.#completeRequest.bind(this));
 
                 console.error(onerror);
         });

--- a/public/js/controllers/feed-users-controller.js
+++ b/public/js/controllers/feed-users-controller.js
@@ -55,12 +55,14 @@ export default class FeedUsersController extends Controller {
     #actionCallback = (data, selectedTags, isEvent) => {
         this.view.render(data, selectedTags, isEvent);
         document.querySelectorAll('.search-tag').forEach((tag) => {
-            tag.addEventListener('click', this.#highlightTag);
+            this.addEventHandler(tag, 'click', this.#highlightTag);
+            // tag.addEventListener('click', this.#highlightTag);
         });
         if (data) {
             this.#setUpVoteButtons();
         }
-        document.getElementById('form').addEventListener('submit', this.#setOptions);
+        this.addEventHandler(document.getElementById('form'), 'submit', this.#setOptions);
+        // document.getElementById('form').addEventListener('submit', this.#setOptions);
         SetSliders(18, 60, 25);
     };
 

--- a/public/js/controllers/login-controller.js
+++ b/public/js/controllers/login-controller.js
@@ -32,12 +32,12 @@ export default class LoginController extends Controller {
         let auth = document.body.getElementsByClassName('auth')[0];
         if (auth) {
             this.form = document.getElementById('form');
-            this.form.addEventListener('submit', this.#loginSubmitHandler.bind(this));
+            this.addEventHandler(this.form, 'submit', this.#loginSubmitHandler);
 
             this.inputs = this.form.getElementsByClassName('input input__auth');
             for (let input of this.inputs) {
-                input.addEventListener('focus', this.#removeErrorMessage.bind(this));
-                input.addEventListener('blur', this.#checkInputHandler.bind(this));
+                this.addEventHandler(input, 'focus', this.#removeErrorMessage);
+                this.addEventHandler(input, 'blur', this.#checkInputHandler);
             }
         }
     }

--- a/public/js/controllers/medium-event-search-controller.js
+++ b/public/js/controllers/medium-event-search-controller.js
@@ -28,10 +28,12 @@ export default class MediumEventSearchController extends Controller {
     action() {
         super.action();
         this.view.render();
-        document.querySelectorAll('.search-tag').forEach((tag) => {
-            tag.addEventListener('click', this._highlightTag);
+        document.querySelectorAll('.search_tag').forEach((tag) => {
+            this.addEventHandler(tag, 'click', this._highlightTag);
+            // tag.addEventListener('click', this._highlightTag);
         });
-        document.getElementById('form').addEventListener('submit', this._setOptions)
+        this.addEventHandler(document.getElementById('form'), 'submit', this._setOptions);
+        // document.getElementById('form').addEventListener('submit', this._setOptions)
     }
 
     _highlightTag(event) {

--- a/public/js/controllers/my-controller.js
+++ b/public/js/controllers/my-controller.js
@@ -25,7 +25,8 @@ export default class MyController extends Controller {
         document.addEventListener('DOMContentLoaded', (event) => {
             this.circles = document.getElementsByClassName('circle');
             for (let iii = 0; iii < this.circles.length; iii++) {
-                this.circles[iii].addEventListener('click', this.redirects[iii].bind(this), false);
+                this.addEventHandler(this.circles[iii], 'click', this.redirects[iii]);
+                // this.circles[iii].addEventListener('click', this.redirects[iii].bind(this), false);
             }
         });
     }

--- a/public/js/controllers/profile-controller.js
+++ b/public/js/controllers/profile-controller.js
@@ -51,18 +51,24 @@ export default class ProfileController extends MyController {
                     this.user = profile;
 
                     const photoInput = document.getElementById('photoUpload');
-                    photoInput.addEventListener('change', this.#handleFile.bind(this), false);
+                    this.addEventHandler(photoInput, 'change', this.#handleFile);
+                    // photoInput.addEventListener('change', this.#handleFile.bind(this), false);
                     const textInput = document.getElementsByClassName('re_btn re_btn__filled')[0];
-                    textInput.addEventListener('click', this.#handleInfo.bind(this), false);
-                    document.querySelector('.tags_redirect').addEventListener(
-                        'click', this.#showModalTags.bind(this), false);
+                    this.addEventHandler(textInput, 'click', this.#handleInfo);
+                    this.addEventHandler(document.querySelector('.tags_redirect'), 'click', this.#showModalTags);
+                    // textInput.addEventListener('click', this.#handleInfo.bind(this), false);
+                    // document.querySelector('.tags_redirect').addEventListener(
+                    //     'click', this.#showModalTags.bind(this), false);
                     // TODO: i dunno how to get last item to remove kek in the future
                     const settings = document.getElementsByClassName('re_btn re_btn__outline kek')[0];
-                    settings.addEventListener('click', this.#profileSettings.bind(this), false);
-                    document.querySelector('.profile-left__tags').addEventListener(
-                        'click', this.#removeTag, false);
-                    document.getElementsByClassName('re_btn re_btn__outline logout')[0].addEventListener(
-                        'click', logoutRedirect, false);
+                    this.addEventHandler(settings, 'click', this.#profileSettings);
+                    this.addEventHandler(document.querySelector('.profile-left__tags'), 'click', this.#removeTag);
+                    this.addEventHandler(document.getElementsByClassName('re_btn re_btn__outline logout')[0], 'click', logoutRedirect);
+                    // settings.addEventListener('click', this.#profileSettings.bind(this), false);
+                    // document.querySelector('.profile-left__tags').addEventListener(
+                    //     'click', this.#removeTag, false);
+                    // document.getElementsByClassName('re_btn re_btn__outline logout')[0].addEventListener(
+                    //     'click', logoutRedirect, false);
                 } else {
                     console.error('You have no rights');
                     console.log(profile);
@@ -75,7 +81,8 @@ export default class ProfileController extends MyController {
     #handleFile = (event) => {
         if (event.target.files && event.target.files[0]) {
             let FR = new FileReader();
-            FR.addEventListener('load', this.#handleSelectImg.bind(this));
+            this.addEventHandler(FR, 'load', this.#handleSelectImg);
+            // FR.addEventListener('load', this.#handleSelectImg.bind(this));
             FR.readAsDataURL(event.target.files[0]);
         }
     };
@@ -293,9 +300,11 @@ export default class ProfileController extends MyController {
         this.editView = new ProfileEditView(this.parent);
         this.editView.render(this.user);
         const closeBtn = document.getElementsByClassName('profile-edit__icon')[0];
-        closeBtn.addEventListener('click', this.#removeProfileSettings.bind(this));
+        this.addEventHandler(closeBtn, 'click', this.#removeProfileSettings);
+        // closeBtn.addEventListener('click', this.#removeProfileSettings.bind(this));
         const table = document.getElementsByClassName('profile-edit__table')[0];
-        table.addEventListener('click', this.#drawUnfoldedLine.bind(this));
+        this.addEventHandler(table, 'click', this.#drawUnfoldedLine);
+        // table.addEventListener('click', this.#drawUnfoldedLine.bind(this));
     };
 
 

--- a/public/js/controllers/signup-controller.js
+++ b/public/js/controllers/signup-controller.js
@@ -31,12 +31,15 @@ export default class SignUpController extends Controller {
         let auth = document.body.getElementsByClassName('auth')[0];
         if (auth) {
             this.form = document.getElementById('form');
-            this.form.addEventListener('submit', this.#signUpSubmitHandler.bind(this));
+            this.addEventHandler(this.form, 'submit', this.#signUpSubmitHandler);
+            // this.form.addEventListener('submit', this.#signUpSubmitHandler.bind(this));
 
             this.inputs = this.form.getElementsByClassName('input input__auth');
             for (let input of this.inputs) {
-                input.addEventListener('focus', this.#removeErrorMessage.bind(this));
-                input.addEventListener('blur', this.#checkInputHandler.bind(this));
+                this.addEventHandler(input, 'focus', this.#removeErrorMessage);
+                this.addEventHandler(input, 'blur', this.#checkInputHandler);
+                // input.addEventListener('focus', this.#removeErrorMessage.bind(this));
+                // input.addEventListener('blur', this.#checkInputHandler.bind(this));
             }
         }
     }

--- a/public/js/core/controller.js
+++ b/public/js/core/controller.js
@@ -15,6 +15,8 @@ export default class Controller {
      */
     constructor(parent) {
         this.parent = parent;
+        this.eventHandlers = [];
+
         document.addEventListener('DOMContentLoaded', () => {
             // TODO: add eventlisteners
         });
@@ -24,8 +26,14 @@ export default class Controller {
      * virtual destructor
      */
     destructor() {
+        if (this.eventHandlers.length !== 0) {
+            for (const nodeVal of this.eventHandlers) {
+                for (const eventVal of nodeVal.events) {
+                        this.removeEventHandler(nodeVal.htmlNode, eventVal.event);
+                }
+            }
+        }
         this.parent.innerHTML = '';
-        // todo: remove listeners
     }
 
     /**
@@ -89,4 +97,72 @@ export default class Controller {
         // TODO: remove all active links
         //  Add active link on chosen index (look in my-controller.js)
     };
+
+    /*
+    [{
+      htmlNode: домэлемент,
+      events: [{
+            event: 'click',
+            handlers: [
+                   callback,
+                   capture
+            ]
+      }]
+    }]
+    */
+    addEventHandler = (node, event, handler) => {
+        let foundNode = false;
+        let foundEvent = false;
+        if (this.eventHandlers.length !== 0) {
+            for (const nodeVal of this.eventHandlers) {
+                if (nodeVal.htmlNode == node) {
+                    foundNode = true;
+                    for (const eventVal of nodeVal.events) {
+                        if (eventVal.event == event) {
+                            foundEvent = true;
+                            break;
+                        }
+                    }
+                    if (!foundEvent) {
+                        node.addEventListener(event, handler);
+                        nodeVal.events.push({
+                            event: event,
+                            handler: handler,
+                        });
+                    }
+                    break;
+                }
+            }
+        }
+        if (!foundNode) {
+            node.addEventListener(event, handler);
+            this.eventHandlers.push({
+                htmlNode: node,
+                events: [{
+                    event: event,
+                    handler: handler,
+                }]
+            });
+        }
+    }
+
+    removeEventHandler = (node, event) => {
+        if (this.eventHandlers.length !== 0) {
+            this.eventHandlers = [...this.eventHandlers.filter(nodeVal => {
+                if (nodeVal.htmlNode == node) {
+                    nodeVal.events = [...nodeVal.events.filter(eventVal => {
+                        if (eventVal.event == event) {
+                            node.removeEventListener(event, eventVal.handler);
+                            return false;
+                        } else {
+                            return true;
+                        }
+                    })];
+                    return false;
+                } else {
+                    return true;
+                }
+            })];
+        }
+    }
 }

--- a/public/js/core/controller.js
+++ b/public/js/core/controller.js
@@ -51,9 +51,11 @@ export default class Controller {
             console.log('No internet connection');
         }).then(() => {
             const managePanel = document.getElementsByClassName('header__manage')[0];
-            managePanel.addEventListener('click', this.#controlBtnPressed.bind(this));
+            this.addEventHandler(managePanel, 'click', this.#controlBtnPressed);
+            // managePanel.addEventListener('click', this.#controlBtnPressed.bind(this));
             const logo = document.getElementsByClassName('header__logo gradient-text')[0];
-            logo.addEventListener('click', this.#homeRedirect.bind(this));
+            this.addEventHandler(logo, 'click', this.#homeRedirect);
+            // logo.addEventListener('click', this.#homeRedirect.bind(this));
         });
     }
 
@@ -113,36 +115,38 @@ export default class Controller {
     addEventHandler = (node, event, handler) => {
         let foundNode = false;
         let foundEvent = false;
-        if (this.eventHandlers.length !== 0) {
-            for (const nodeVal of this.eventHandlers) {
-                if (nodeVal.htmlNode == node) {
-                    foundNode = true;
-                    for (const eventVal of nodeVal.events) {
-                        if (eventVal.event == event) {
-                            foundEvent = true;
-                            break;
+        if (node) {
+            if (this.eventHandlers.length !== 0) {
+                for (const nodeVal of this.eventHandlers) {
+                    if (nodeVal.htmlNode == node) {
+                        foundNode = true;
+                        for (const eventVal of nodeVal.events) {
+                            if (eventVal.event == event) {
+                                foundEvent = true;
+                                break;
+                            }
                         }
+                        if (!foundEvent) {
+                            node.addEventListener(event, handler);
+                            nodeVal.events.push({
+                                event: event,
+                                handler: handler,
+                            });
+                        }
+                        break;
                     }
-                    if (!foundEvent) {
-                        node.addEventListener(event, handler);
-                        nodeVal.events.push({
-                            event: event,
-                            handler: handler,
-                        });
-                    }
-                    break;
                 }
             }
-        }
-        if (!foundNode) {
-            node.addEventListener(event, handler);
-            this.eventHandlers.push({
-                htmlNode: node,
-                events: [{
-                    event: event,
-                    handler: handler,
-                }]
-            });
+            if (!foundNode) {
+                node.addEventListener(event, handler);
+                this.eventHandlers.push({
+                    htmlNode: node,
+                    events: [{
+                        event: event,
+                        handler: handler,
+                    }]
+                });
+            }
         }
     }
 

--- a/public/js/core/controller.js
+++ b/public/js/core/controller.js
@@ -105,10 +105,7 @@ export default class Controller {
       htmlNode: домэлемент,
       events: [{
             event: 'click',
-            handlers: [
-                   callback,
-                   capture
-            ]
+            handler: callback
       }]
     }]
     */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 
 module.exports = {
     mode: 'development',
+    devtool: 'source-map',
     entry: './public/js/index.js',
     output: {
         filename: 'bundle.js',


### PR DESCRIPTION
# Issue
При создании новой страницы и, как следствие, нового контроллера появляются новые функциональные элементы (кнопки, inputs, формы итд).
Для подобных элементов обязательно будут добавлены обработчики событий (`click`, `submit`, `focus`, `blur`...):
```js
addEventListener(event, handler);
```
Однако ранее не существовало соответствующей операции отвязки:
```js
removeEventListener(event, handler);
```

# Solution
В базовый класс `Controller` были добавлены 2 новые функции и 1 свойство:
```js
this.eventHandlers = [];
...
addEventHandler = (node, event, handler) => {...}
removeEventHandler = (node, event) => {...}
```

Структура хранения функциональных элементов и событий обощенно выглядит так:
```js
    [{
      htmlNode: домэлемент,
      events: [{
            event: 'click',
            handler: callback
      }]
    }]
```

Теперь из производного класса в моменты операции связывания функционального элемента и его обработчика достаточно вызвать:
```js
this.addEventHandler(this.form, 'submit', this.#loginSubmitHandler);
```

При переключении на новую страницу старый контроллер будет уничжен с вызовом соотвествующего деструктора, в котором итерационно будут уничтожены все обработчки вызовом:
```js
    destructor() {
        if (this.eventHandlers.length !== 0) {
            for (const nodeVal of this.eventHandlers) {
                for (const eventVal of nodeVal.events) {
                        this.removeEventHandler(nodeVal.htmlNode, eventVal.event);
                }
            }
        }
        this.parent.innerHTML = '';
    }
```

# Additional comments

Если вы используете стрелочные функции, то вы сразу определяете контекст их выполнения на окружающий scope, которым является класс, что избавляет вас от необходимости постоянно делать `.bind(this)`.