### PR TITLE
[UTILS] Add CSRF token extraction and pulling to all fetch reqs

### DIFF
--- a/public/js/core/network.js
+++ b/public/js/core/network.js
@@ -13,7 +13,7 @@ export default class NetworkModule {
     static fetchGet = ({
                 path = '/',
             } = {}) => {
-        const token = getCookie('csrftoken');
+        const token = getCookie('csrf');
         return fetch(settings.url + ':' + settings.port + settings.api + path, {
             method: 'GET',
             mode: 'cors',
@@ -33,7 +33,7 @@ export default class NetworkModule {
                     path = '/',
                     body = null,
                 } = {}) => {
-        const token = getCookie('csrftoken');
+        const token = getCookie('csrf');
         return fetch(settings.url + ':' + settings.port + settings.api + path, {
             method: 'POST',
             mode: 'cors',
@@ -55,7 +55,7 @@ export default class NetworkModule {
         path = '/',
         body = null,
     } = {}) => {
-        const token = getCookie('csrftoken');
+        const token = getCookie('csrf');
         return fetch(settings.url + ':' + settings.port + settings.api + path, {
             method: 'PUT',
             mode: 'cors',

--- a/public/js/core/network.js
+++ b/public/js/core/network.js
@@ -1,4 +1,5 @@
 import settings from '../../settings/config.js';
+import getCookie from '../utils/csrf.js';
 
 /**
  * The class implements methods for calling communicating with the server API
@@ -12,10 +13,14 @@ export default class NetworkModule {
     static fetchGet = ({
                 path = '/',
             } = {}) => {
+        const token = getCookie('csrftoken');
         return fetch(settings.url + ':' + settings.port + settings.api + path, {
             method: 'GET',
             mode: 'cors',
             credentials: 'include',
+            headers: {
+                'X-CSRF-Token': token
+            },
         });
     };
 
@@ -28,12 +33,14 @@ export default class NetworkModule {
                     path = '/',
                     body = null,
                 } = {}) => {
+        const token = getCookie('csrftoken');
         return fetch(settings.url + ':' + settings.port + settings.api + path, {
             method: 'POST',
             mode: 'cors',
             credentials: 'include',
             headers: {
                 'Content-Type': 'application/json; charset=utf-8',
+                'X-CSRF-Token': token
             },
             body: JSON.stringify(body)
         });
@@ -48,12 +55,14 @@ export default class NetworkModule {
         path = '/',
         body = null,
     } = {}) => {
+        const token = getCookie('csrftoken');
         return fetch(settings.url + ':' + settings.port + settings.api + path, {
             method: 'PUT',
             mode: 'cors',
             credentials: 'include',
             headers: {
                 'Content-Type': 'application/json; charset=utf-8',
+                'X-CSRF-Token': token
             },
             body: JSON.stringify(body)
         });

--- a/public/js/utils/csrf.js
+++ b/public/js/utils/csrf.js
@@ -1,0 +1,23 @@
+'use strict';
+
+/**
+ * Get CSRF token by key
+ * @param {String} name
+ * @returns {String}
+ */
+const getCookie = (name) => {
+    if (!document.cookie) {
+        return void 0;
+    }
+  
+    const xsrfCookies = document.cookie.split(';')
+      .map(c => c.trim())
+      .filter(c => c.startsWith(name + '='));
+  
+    if (xsrfCookies.length === 0) {
+        return void 0;
+    }
+    return decodeURIComponent(xsrfCookies[0].split('=')[1]);
+}
+
+export default getCookie;


### PR DESCRIPTION
# Issue
При создании создании очередного запроса с клиента в его тело браузером автоматически добавляется заголовок:

```js
Set-Cookie: token=eyJhbGci...dd0yj4; Expires=Sat, 02 May 2020 13:20:19 GMT; HttpOnly
```

Что позволяет атакующей странице воспользоваться данными этой куки из браузера пользователя, что позволяет ей легко вставлять ее как используя поддельную форму, так и создав AJAX запрос без ведома пользователя с атрибутом ```withCredentials``` (https://habr.com/ru/company/oleg-bunin/blog/412855/).

Довольно приятно эта проблема рассмотрена также здесь: https://stackoverflow.com/questions/20504846/why-is-it-common-to-put-csrf-prevention-tokens-in-cookies

# Solution
Решение основано на https://stackoverflow.com/questions/40893537/fetch-set-cookies-and-csrf.
  1. Обозначаем имя ключа, по которому можно получить CSRF.
  2. Извлекаем с помощью новой функции-утилиты.
  3. Вставляем заголовок ```'X-CSRF-Token': token```.

Возможно дополнительно потребуется заголовок ```'X-Requested-With': 'XMLHttpRequest',```.
